### PR TITLE
chore: upgrade pypy to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG USER_UID=2000
 ARG USER_GID=$USER_UID
 ARG WORKDIR=/srv/www/
 
-FROM pypy:3.10-slim as builder
+FROM pypy:3.11-slim as builder
 ARG USERNAME
 ARG USER_UID
 ARG USER_GID
@@ -37,7 +37,7 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN mkdir /data/
 RUN chmod 777 /data/
 
-FROM pypy:3.10-slim as runtime
+FROM pypy:3.11-slim as runtime
 ARG USERNAME
 ARG WORKDIR
 WORKDIR $WORKDIR

--- a/whole_app/spell.py
+++ b/whole_app/spell.py
@@ -31,7 +31,7 @@ class SpellCheckService:
         """Initialize machinery."""
         self._input_text = request_payload.text
         self._exclusion_words = exclusion_words if exclusion_words else []
-        self._exclusion_words.extend(SETTINGS.exclusion_words_set())
+        self._exclusion_words.extend(SETTINGS.exclusion_words_set)
 
         if request_payload.exclude_urls:
             for one_url in self._url_extractor.find_urls(self._input_text):


### PR DESCRIPTION
## Summary
- use PyPy 3.11 base image in Dockerfile
- treat exclusion words set as property to prevent runtime error

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a26b38caec832583098465f4d48254