### PR TITLE
Use Python 3.12 in CI for cachebox wheel

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,7 +30,7 @@ jobs:
   submit-coverage:
     runs-on: ubuntu-latest
     container:
-      image: python:3.10.12-slim
+      image: python:3.12-slim
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -82,7 +82,7 @@ jobs:
     needs: [build-and-publish]
     runs-on: ubuntu-latest
     container:
-      image: python:3.10.12-slim
+      image: python:3.12-slim
     steps:
       - uses: actions/checkout@v3
       - run: |


### PR DESCRIPTION
## Summary
- run coverage and DockerHub README jobs on Python 3.12 so cachebox installs from wheel

## Testing
- `uv run ruff check . --no-fix`
- `uv run mypy .`
- `uv run pytest -n3`

------
https://chatgpt.com/codex/tasks/task_e_68a786b126ec8325b9ddb292f1645b8f