### PR TITLE
chore: use python 3.11 in workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       pages: write
       id-token: write
     container:
-      image: pypy:3.11-slim
+      image: python:3.11-slim
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: 'pypy3.11'
+          python-version: '3.11'
       - run: |
           pip install uv
           uv version $(python -c "import os; print(os.getenv('GITHUB_REF').lstrip('/').replace('refs/tags/v', ''));")
@@ -106,7 +106,7 @@ jobs:
     needs: [build-and-publish]
     runs-on: ubuntu-latest
     container:
-      image: pypy:3.11-slim
+      image: python:3.11-slim
     steps:
       - uses: actions/checkout@v3
       - run: |


### PR DESCRIPTION
## Summary
- use python:3.11-slim image in coverage and readme update jobs
- set build job to install CPython 3.11 instead of pypy3.11

## Testing
- `uv run ruff check . --no-fix`
- `uv run mypy .`
- `uv run pytest -n3 .`


------
https://chatgpt.com/codex/tasks/task_e_68a794cc22e883259f860d84393a1699