### PR TITLE
Automate README updates in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,23 @@ on:
       - v*
 
 jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y enchant-2 hunspell-ru hunspell-es hunspell-de-de hunspell-fr hunspell-pt-pt
+          pip install uv
+          uv sync --group dev
+          uv run make update-readme
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: auto-update README"
+          file_pattern: README.md
   py-lint-and-test:
     runs-on: ubuntu-latest
     steps:
@@ -112,7 +129,6 @@ jobs:
           apt-get install make
           pip install uv
           uv sync --group dev
-          uv run make update-readme
           uv run make update-dockerhub-readme
       - uses: peter-evans/dockerhub-description@v3
         with:

--- a/README.md
+++ b/README.md
@@ -83,13 +83,8 @@ You cand find it here https://github.com/xfenix/spellcheck-microservice/releases
 - For Debian/Ubuntu `apt-get install -y enchant-2 hunspell-ru`
 - `uv sync --group dev`
 - `source .venv/bin/activate`
-- Run `touch .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`
-- Paste following contents in file `.git/hooks/pre-commit`:
-  ```sh
-  uv run make update-readme
-  git add README.md
-  ```
 - Execute `make` command to run local development server
+- README is automatically updated in the CI pipeline for each commit
 
 ### Notes
 


### PR DESCRIPTION
## Summary
- remove manual pre-commit hook instructions from documentation
- add CI job to auto-update README on each commit
- keep Docker Hub README update while dropping redundant local regeneration

## Testing
- `uv run make lint`
- `uv run make test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a2bfada08325930a739bbfc28c72