### PR TITLE
Use latest Docker tag for README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Also it supports feature called «user dictionaries» — user can add his own w
 
 ## Quickstart
 
-- `docker run -p 10113:10113 -t --mount source=spellcheck-dicts,target=/data/ xfenix/spellcheck-microservice:main`
+- `docker run -p 10113:10113 -t --mount source=spellcheck-dicts,target=/data/ xfenix/spellcheck-microservice:latest`
 - check http://localhost:10113/docs/ for full REST documentation
 - main REST endpoint you will be needed is http://localhost:10113/api/check/ (this will be available without authorization)
 
@@ -48,7 +48,7 @@ Note: all docker & docker-compose variants use named volumes to store user dicti
 
 #### Plain docker
 
-`docker run  -p 10113:10113 -t --mount source=spellcheck-dicts,target=/data/ xfenix/spellcheck-microservice:main`
+`docker run  -p 10113:10113 -t --mount source=spellcheck-dicts,target=/data/ xfenix/spellcheck-microservice:latest`
 
 #### Docker-compose
 
@@ -58,7 +58,7 @@ Note: all docker & docker-compose variants use named volumes to store user dicti
 version: "3.9"
 services:
   spellcheck:
-    image: xfenix/spellcheck-microservice:main
+    image: xfenix/spellcheck-microservice:latest
     ports:
       - "10113:10113"
     volumes:

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -6,23 +6,28 @@ import typing
 
 
 def parse_last_git_tag() -> str:
-    last_tag_from_environment: typing.Final[str | None] = os.getenv("GITHUB_REF_NAME")
-    if last_tag_from_environment is None:
-        git_tags_list: typing.Final = shlex.split(
-            "git rev-list --tags --max-count=1",
-        )
-        last_tag_hash: typing.Final = subprocess.check_output(git_tags_list).strip().decode()  # noqa: S603
-        git_tag_description: typing.Final = shlex.split(
-            f"git describe --tags {last_tag_hash}",
-        )
-        return subprocess.check_output(git_tag_description).strip().decode().lstrip("v")  # noqa: S603
-    return last_tag_from_environment.lstrip("v")
+    environment_ref_name_raw: typing.Final[str | None] = os.getenv("GITHUB_REF_NAME")
+    if environment_ref_name_raw is not None:
+        environment_ref_name: str = environment_ref_name_raw.lstrip("v")
+        if re.fullmatch(r"\d+\.\d+\.\d+", environment_ref_name):
+            return environment_ref_name
+        return "latest"
+
+    git_tags_command: typing.Final[list[str]] = shlex.split(
+        "git rev-list --tags --max-count=1",
+    )
+    last_tag_hash: typing.Final[str] = subprocess.check_output(git_tags_command).strip().decode()  # noqa: S603
+    describe_command: typing.Final[list[str]] = shlex.split(
+        f"git describe --tags {last_tag_hash}",
+    )
+    return subprocess.check_output(describe_command).strip().decode().lstrip("v")  # noqa: S603
 
 
 def replace_tag_in_readme(readme_text: str, new_tag: str) -> str:
     return re.sub(
-        r"(xfenix/spellcheck-microservice\:)(\d{1,}\.\d{1,}\.\d{1,})",
+        r"(xfenix/spellcheck-microservice\:)([\w\.-]+)",
         r"\g<1>" + new_tag,
         readme_text,
         flags=re.IGNORECASE | re.DOTALL,
     )
+


### PR DESCRIPTION
## Summary
- default release tag to `latest` when branch name is not a version
- update README examples to use `xfenix/spellcheck-microservice:latest`

## Testing
- `ruff check scripts/_helpers.py`
- `mypy scripts/_helpers.py`
- `pytest` *(fails: enchant.errors.DefaultLanguageNotFoundError: ru_RU)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ac4947c88325ba13e1256e963c22